### PR TITLE
Update Node.js version requirements and CI configurations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [21.x, 22.x]
+        node-version: [22.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 21
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
           cache: npm
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Installation
 
 Requirements
 
-- Node >=18 (global `fetch` available in Node 18+ and modern runtimes)
+- Node >=22 (global `fetch` available in Node 22+ and modern runtimes)
 - Peer dependency: `zod` (>=4 <5) must be installed in your project
 
 Quick Start
@@ -91,7 +91,7 @@ Notes
 
 CI
 
-- A GitHub Actions workflow is provided at `.github/workflows/ci.yml` which runs lint, build, and tests on Node 18 and 20.
+- A GitHub Actions workflow is provided at `.github/workflows/ci.yml` which runs lint, build, and tests on Node 22.
 - If your default branch is not `main` or `master`, update the branches in the workflow trigger.
 
 CD (npm publish)
@@ -105,7 +105,7 @@ CD (npm publish)
 
 Troubleshooting
 
-- Missing `fetch` in Node: ensure you are on Node >=18 or add the `undici` polyfill shown above.
+- Missing `fetch` in Node: ensure you are on Node >=22 or add the `undici` polyfill shown above.
 - Zod not found: install the peer dependency with `npm i zod` (requires `>=4 <5`).
 - ESM import errors: confirm your project uses ESM (`"type": "module"`) or configure your bundler accordingly.
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "sideEffects": false,
   "engines": {
-    "node": ">=21"
+    "node": ">=22"
   },
   "scripts": {
     "dev": "tsx watch src/index.ts",


### PR DESCRIPTION
- Bump Node.js version requirement in package.json and README.md to >=22.
- Update GitHub Actions workflows to use Node.js 22 for CI and publishing steps.
- Adjust troubleshooting instructions to reflect the new Node.js version.